### PR TITLE
fix: nvim-cmp keymaps working as expected

### DIFF
--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -5,25 +5,59 @@ return {
         local cmp = require('cmp')
         local lspkind = require('lspkind')
         cmp.setup({
+            completion = {
+                autocomplete = false,
+                completeopt = "menu,menuone,noinsert"
+            },
             snippet = {
                 expand = function(args)
                     require('luasnip').lsp_expand(args.body)
                 end,
             },
-            mappings = {
-                ["<C-d"] = cmp.mapping.scroll_docs(-4),
-                ["<C-f"] = cmp.mapping.scroll_docs(4),
-                ["<C-e"] = cmp.mapping.close(),
-                ["<CR"] = cmp.mapping.confirm({
-                    behavior = cmp.ConfirmBehavior.Insert,
-                    select = true
+            window = {},
+            mapping = {
+                ['<Down>'] = {
+                    i = cmp.mapping.select_next_item({ behavior = cmp.SelectBehavior.Select }),
+                },
+                ['<Up>'] = {
+                    i = cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Select }),
+                },
+                ['<C-n>'] = {
+                    i = function()
+                        if cmp.visible() then
+                            cmp.select_next_item({ behavior = cmp.SelectBehavior.Insert })
+                        else
+                            cmp.complete()
+                        end
+                    end,
+                },
+                ['<C-p>'] = {
+                    i = function()
+                        if cmp.visible() then
+                            cmp.select_prev_item({ behavior = cmp.SelectBehavior.Insert })
+                        else
+                            cmp.complete()
+                        end
+                    end,
+                },
+                ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+                ["<C-f>"] = cmp.mapping.scroll_docs(4),
+                ["<C-Space>"] = cmp.mapping.complete(),
+                ["<C-e>"] = cmp.mapping.abort(),
+                ["<CR>"] = cmp.mapping.confirm({ select = true }),
+                ["<S-CR>"] = cmp.mapping.confirm({
+                    behavior = cmp.ConfirmBehavior.Replace,
+                    select = true,
                 }),
-                ["<C-space>"] = cmp.mapping.complete()
+                ["<C-CR>"] = function(fallback)
+                    cmp.abort()
+                    fallback()
+                end,
             },
             sources = {
                 { name = "nvim_lsp" },
                 { name = "path" },
-                { name = "luasnip" }, -- pas sur que j'ai envie d'avoir ça
+                { name = "luasnip" },
                 { name = "buffer", keyword_length = 5 },
             },
             formatting = {


### PR DESCRIPTION
Just fixing some behaviors with the help of nvim-cmp and Lazy.vim source code