### PR TITLE
fix: fix winblend behavior with iterm2

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -15,7 +15,8 @@ return {
             defaut = {
                 color_devicons = true,
                 prompt_prefix = '> ',
-                path_display = {"truncate", "shorten"}
+                path_display = {"truncate", "shorten"},
+                winblend = 0
             },
             extensions = {
                 fzf = {


### PR DESCRIPTION
Sometime when I open Telescope i have a weird winblend error.

"Option 'winblend' value must be Integer".

The error occurs only on iTerm2, on Mac M2.

A simple fix is just to assign winblend value to the telescope window.